### PR TITLE
Taking archieveLocation in to consideration when running the Maven-Car-Deploy-Plugin

### DIFF
--- a/dependencies/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/DeployCarMojo.java
+++ b/dependencies/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/DeployCarMojo.java
@@ -234,12 +234,16 @@ public class DeployCarMojo extends AbstractMojo {
 		}
 		
 	    File carFile = null;
-		if (finalName == null) {
-			carFile = new File(target + "/" + project.getArtifactId() + "_"
-					+ project.getVersion() + ".car");
-		}else{
-			carFile = new File(target + "/" + finalName + ".car");
-		}
+	    if(archiveLocation !=null){
+	    	carFile = archiveLocation;
+	    }else{
+	    	if (finalName == null) {
+	    		carFile = new File(target + "/" + project.getArtifactId() + "_"
+	    				+ project.getVersion() + ".car");
+	    	}else{
+	    		carFile = new File(target + "/" + finalName + ".car");
+	    	}
+	    }
 		
 	    if(operation.equalsIgnoreCase("deploy")){
 		    try {


### PR DESCRIPTION
CAR-Deploy-Plugin does not consider the archieveLocation parameter to use an artifact exist in a different location. This fix make sure we do consider that as well.
