### PR TITLE
Fix detecting supported JDK on startup

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.platform.core/src/org/wso2/developerstudio/eclipse/platform/core/startup/alert/JavaVersionAlertHandler.java
+++ b/plugins/org.wso2.developerstudio.eclipse.platform.core/src/org/wso2/developerstudio/eclipse/platform/core/startup/alert/JavaVersionAlertHandler.java
@@ -33,7 +33,7 @@ import org.wso2.developerstudio.eclipse.platform.core.utils.Constants;
  */
 public class JavaVersionAlertHandler implements IStartup {
 	private static final String JAVA_VERSION_PROPERTY = "java.version";
-	private static final String ALERT_TITLE = "Java Version Update Required";
+	private static final String ALERT_TITLE = "Java Version Not Supported";
 	private static final String CONTINUE_BUTTON = "Continue";
 	private static final String EXIT_BUTTON = "Exit";
 	private static final String DOT_SEPARATOR = ".";
@@ -45,7 +45,8 @@ public class JavaVersionAlertHandler implements IStartup {
 		// If Developer Studio starts with an unsupported version, then show a
 		// warning
 		double detectedJavaVersion = getJavaVersionInDouble(version);
-		if (detectedJavaVersion < Constants.MINIMUM_REQUIRED_JAVA_VERSION) {
+		if (detectedJavaVersion < Constants.MINIMUM_REQUIRED_JAVA_VERSION
+				|| detectedJavaVersion > Constants.MAXIMUM_SUPPORTED_JAVA_VERSION) {
 			final IWorkbench workbench = PlatformUI.getWorkbench();
 			workbench.getDisplay().asyncExec(new Runnable() {
 				public void run() {
@@ -62,23 +63,28 @@ public class JavaVersionAlertHandler implements IStartup {
 
 						shell.setLocation(xCenter, yCenter);
 
-						String warningMessage =
-						                        Constants.DETECTED_JAVA_VERSION_MESSAGE + version + "\n" +
-						                                Constants.RECOMMENDED_JAVA_VERSION_MESSAGE +
-						                                Constants.MINIMUM_REQUIRED_JAVA_VERSION + ".x" + "\n" +
-						                                Constants.JAVA_VERSION_ALERT_MESSAGE + "\n" +
-						                                Constants.JAVA_VERSION_CONTINUE_MESSAGE;
-						MessageDialog dialog =
-						                       new MessageDialog(shell, ALERT_TITLE, null, warningMessage,
-						                               MessageDialog.ERROR,
-						                               new String[] { CONTINUE_BUTTON, EXIT_BUTTON }, 0) {
-							                       protected void buttonPressed(int buttonId) {
-								                       if (buttonId == 1) {
-									                       System.exit(0);
-								                       }
-								                       super.buttonPressed(buttonId);
-							                       }
-						                       };
+						String str = (Constants.MAXIMUM_SUPPORTED_JAVA_VERSION
+								== Constants.MINIMUM_REQUIRED_JAVA_VERSION) ?
+								"\n" :
+								(" - " + Constants.MAXIMUM_SUPPORTED_JAVA_VERSION + ".x" + "\n");
+
+						String warningMessage = Constants.DETECTED_JAVA_VERSION_MESSAGE + version + "\n"
+								+ Constants.RECOMMENDED_JAVA_VERSION_MESSAGE + Constants.MINIMUM_REQUIRED_JAVA_VERSION
+								+ ".x" + str + Constants.JAVA_VERSION_ALERT_MESSAGE;
+
+						MessageDialog dialog = new MessageDialog(shell, ALERT_TITLE, null, warningMessage,
+								MessageDialog.ERROR, new String[] { EXIT_BUTTON }, 0) {
+
+							protected void buttonPressed(int buttonId) {
+								System.exit(0);
+							}
+
+							protected void handleShellCloseEvent() {
+								System.exit(0);
+							}
+
+						};
+
 						dialog.open();
 					}
 				}

--- a/plugins/org.wso2.developerstudio.eclipse.platform.core/src/org/wso2/developerstudio/eclipse/platform/core/utils/Constants.java
+++ b/plugins/org.wso2.developerstudio.eclipse.platform.core/src/org/wso2/developerstudio/eclipse/platform/core/utils/Constants.java
@@ -45,7 +45,8 @@ public class Constants extends NLS {
 	public static final String COMMON_TEMPLATE_TYPE = "synapse/template";
 	public static final String JAVA_PROJECT_NATURE = "org.eclipse.jdt.core.javanature";
 
-	public static final double MINIMUM_REQUIRED_JAVA_VERSION = 1.7;
+	public static final double MINIMUM_REQUIRED_JAVA_VERSION = 1.8;
+	public static final double MAXIMUM_SUPPORTED_JAVA_VERSION = 1.8;
 
 	// String constant value declaration, these values loaded from
 	// constants.properties file at run time

--- a/plugins/org.wso2.developerstudio.eclipse.platform.core/src/org/wso2/developerstudio/eclipse/platform/core/utils/constants.properties
+++ b/plugins/org.wso2.developerstudio.eclipse.platform.core/src/org/wso2/developerstudio/eclipse/platform/core/utils/constants.properties
@@ -36,7 +36,5 @@ JAGGERY_NATURE = org.eclipse.php.core.JAGNature
 SERVICE_META_PROJECT_NATURE = org.wso2.developerstudio.eclipse.qos.project.nature
 CONNECTOR_PROJECT_NATURE=org.wso2.developerstudio.eclipse.artifact.connector.project.nature
 DETECTED_JAVA_VERSION_MESSAGE = Detected Java version :
-RECOMMENDED_JAVA_VERSION_MESSAGE = Minimum recommended Java version :
-JAVA_VERSION_ALERT_MESSAGE = Since you are not using minimum recommended Java version, WSO2 Developer Studio will not work \
-  properly
-JAVA_VERSION_CONTINUE_MESSAGE = Do you still want to continue without WSO2 Developer Studio features?
+RECOMMENDED_JAVA_VERSION_MESSAGE=Recommended Java version :
+JAVA_VERSION_ALERT_MESSAGE=Please use a recommended Java version .


### PR DESCRIPTION
Fix for issue https://github.com/wso2/product-ei/issues/2558

This checks whether the detected JDK lies in between the minimum and maximum range of the supported JDK.