### PR TITLE
Introduce default value field to project wizard manifest

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.platform.core/src/org/wso2/developerstudio/eclipse/platform/core/project/model/ProjectOptionData.java
+++ b/plugins/org.wso2.developerstudio.eclipse.platform.core/src/org/wso2/developerstudio/eclipse/platform/core/project/model/ProjectOptionData.java
@@ -30,6 +30,7 @@ public class ProjectOptionData {
 	private String group;
 	private AbstractFieldController fieldController;
 	private ProjectOptionDataType type;
+	private String defaultValue;
 
 	// indent information
 	private Integer verticalIndent;
@@ -261,4 +262,12 @@ public class ProjectOptionData {
 	public int getTextboxHeight() {
 		return height;
 	}
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
 }

--- a/plugins/org.wso2.developerstudio.eclipse.platform.core/src/org/wso2/developerstudio/eclipse/platform/core/project/model/ProjectWizardSettings.java
+++ b/plugins/org.wso2.developerstudio.eclipse.platform.core/src/org/wso2/developerstudio/eclipse/platform/core/project/model/ProjectWizardSettings.java
@@ -177,6 +177,7 @@ public class ProjectWizardSettings extends AbstractXMLDoc {
 					String modelPropertyAttr = getAttribute(dataElement, "modelProperty");
 					String typeAttr = getAttribute(dataElement, "type");
 					String filterAttr = getAttribute(dataElement, "filter");
+					String defaultValueAttr = getAttribute(dataElement, "defaultValue");
 					String fieldControllerAttr = getAttribute(dataElement, "fieldController");
 					AbstractFieldController fieldControllerObj = null;
 					if (fieldControllerAttr != null && !fieldControllerAttr.equals("")) {
@@ -226,6 +227,7 @@ public class ProjectWizardSettings extends AbstractXMLDoc {
 					projectOptionData.setGroup(groupAttr);
 					projectOptionData.setCaption(captionAttr);
 					projectOptionData.setFieldController(fieldControllerObj);
+					projectOptionData.setDefaultValue(defaultValueAttr);
 					optionInfo.getProjectOptionsData().add(projectOptionData);
 				}
 				List<OMElement> projectNaturesElement =

--- a/plugins/org.wso2.developerstudio.eclipse.platform.ui/src/org/wso2/developerstudio/eclipse/platform/ui/wizard/pages/ProjectOptionsDataPage.java
+++ b/plugins/org.wso2.developerstudio.eclipse.platform.ui/src/org/wso2/developerstudio/eclipse/platform/ui/wizard/pages/ProjectOptionsDataPage.java
@@ -1031,6 +1031,9 @@ public class ProjectOptionsDataPage extends WizardPage implements Observer {
 					modelPropertyValue = (Boolean) modelPropertyValueObj;
 				}
 				chkButton.setSelection(modelPropertyValue);
+                if (optionData.getDefaultValue() != null && !optionData.getDefaultValue().isEmpty()) {
+                    chkButton.setSelection(Boolean.parseBoolean(optionData.getDefaultValue()));
+                }
 			}
 		};
 		fieldControllers.put(optionData.getModelProperty(), fieldExecutor);


### PR DESCRIPTION
## Purpose
Introduce default value field to project wizard manifest. This was introduced only for choice field type.
Issue - https://github.com/wso2/product-ei/issues/3422
Ex Usage - 
<data modelProperty="transport.http.choice" type="choice" **defaultValue="true"**>http\</data>


