### PR TITLE
Add default value support for text boxes

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.platform.ui/src/org/wso2/developerstudio/eclipse/platform/ui/wizard/pages/ProjectOptionsDataPage.java
+++ b/plugins/org.wso2.developerstudio.eclipse.platform.ui/src/org/wso2/developerstudio/eclipse/platform/ui/wizard/pages/ProjectOptionsDataPage.java
@@ -1149,6 +1149,9 @@ public class ProjectOptionsDataPage extends WizardPage implements Observer {
 					modelPropertyValue = modelPropertyValueObj.toString();
 				}
 				txt.setData(modelPropertyValue);
+				if (optionData.getDefaultValue() != null && !optionData.getDefaultValue().isEmpty()) {
+					txt.setData(optionData.getDefaultValue());
+				}
 			}
 		};
 		txt.setOnAction(new IOnAction() {


### PR DESCRIPTION
## Purpose
> Enable to add default values for project wizard text boxes

## Goals
> user should be able to define default values like below in project_wizard.xml file
`<data modelProperty="project.remoteRepository" type="string" defaultValue="wso2/micro-integrator">Remote repository</data>`

## Approach
> insert default value to the text box
